### PR TITLE
chore: Update pom.xml and BPM.java (1.21 support)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
                                 </filter>
                             </filters>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <outputFile>C:\Users\josch\Downloads\Mc_Server\server\plugins\BlockParty.jar</outputFile>
+                            <!-- <outputFile>C:\Users\josch\Downloads\Mc_Server\server\plugins\BlockParty.jar</outputFile> -->
                         </configuration>
                     </execution>
                 </executions>
@@ -93,6 +93,17 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
+                <excludes>
+                    <exclude>**/*.jar</exclude>
+                    <exclude>**/*.nbs</exclude>
+                </excludes>
+            </resource>
+            <resource>
+                <directory>src/main/resources/Songs</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>**/*.nbs</include>
+                </includes>
             </resource>
         </resources>
     </build>
@@ -166,7 +177,7 @@
             <artifactId>openaudiomc-api</artifactId>
             <version>6.10.0</version>
             <scope>system</scope>
-            <systemPath>${project.basedir}\src\main\resources\openaudiomc-api.jar</systemPath>
+            <systemPath>${project.basedir}/src/main/resources/openaudiomc-api.jar</systemPath>
             <type>jar</type>
             <optional>true</optional>
         </dependency>

--- a/src/main/java/fr/joschma/BlockParty/BPM.java
+++ b/src/main/java/fr/joschma/BlockParty/BPM.java
@@ -158,7 +158,23 @@ public class BPM extends JavaPlugin {
 
     public BPM() {
         String packet = Bukkit.getServer().getClass().getPackage().getName();
-        version = Integer.valueOf(packet.replace(".", ",").split(",")[3].split("_")[1]);
+        String[] parts = packet.replace(".", ",").split(",");
+        
+        if (parts.length > 3) {
+            String versionPart = parts[3];
+            String[] versionSplit = versionPart.split("_");
+            
+            if (versionSplit.length > 1) {
+                version = Integer.valueOf(versionSplit[1]);
+            } else {
+                version = -1; // def/err val
+                Bukkit.getLogger().warning("Could not parse version from package name: " + packet);
+            }
+        } else {
+            version = -1; // def/err val
+            Bukkit.getLogger().warning("Unexpected package structure: " + packet);
+        }
+        
         noteIsEnable = true;
         OpenAudioMcIsEnable = true;
         MCJukeboxIsEnable = true;


### PR DESCRIPTION
I've fixed and added 1.21 support.

Minor changes were made in `pom.xml` for development on my Mac (feel free to change)